### PR TITLE
Delete HTTP_CONTENT_TYPE and HTTP_CONTENT_LENGTH keys if in %env

### DIFF
--- a/lib/Crust/Handler/SCGI.pm6
+++ b/lib/Crust/Handler/SCGI.pm6
@@ -13,6 +13,10 @@ submethod BUILD(:$host, :$port) {
 
 method run($app) {
     my $fixed = -> %env {
+        # To satisfy Crust's Lint "middleware" paranoia and fascism
+        %env{'HTTP_CONTENT_TYPE'}:delete   if %env{'HTTP_CONTENT_TYPE'}:exists;
+        %env{'HTTP_CONTENT_LENGTH'}:delete if %env{'HTTP_CONTENT_LENGTH'}:exists;
+
         my $input = %env<p6sgi.input>;
         $input = IO::Blob.new($input) if $input && $input ~~ Blob;
         %env<p6sgi.input> = $input;


### PR DESCRIPTION
Crust's Lint filter kills Crust if it detects the HTTP_CONTENT_TYPE or HTTP_CONTENT_LENGTH keys in the environment.

RFCs do not prohibit these keys, only specify that CONTENT_TYPE and CONTENT_LENGTH exist. Some web environments do not delete the two HTTP_* keys.

A pull request was submitted to Crust maintainers that cause the Lint filters to ignore HTTP_* key checks so that Crust can work in certain environments that do not delete HTTP_* keys from the SCGI environment.

The Crust maintainer's position is that Crust must die if those variable keys exist because PSGI says that those variable keys must not exist.

SCGI *can* have these HTTP_* keys without violating RFCs. It is only Crust (following PSGI) that disallows it so extremely.

As the bridge between SCGI and Crust, Crust::Handler::SCGI seems to be the right place to create the PSGI-conforming environment that Crust requires.

This pull request checks to see if HTTP_CONTENT_TYPE or HTTP_CONTENT_LENGTH exists in the environment and deletes them if so, so that Crust will not kill itself in protest.

I do not believe this is a SCGI issue as there is nothing that says these keys cannot exist. It is only Crust that demands it. In the case where I discovered this issue, those keys do not exist, unless a POST is happening.